### PR TITLE
Agregar soporte para la zona horaria del usuario en el modal de estad…

### DIFF
--- a/components/dialogs/GlobalStatsModal.tsx
+++ b/components/dialogs/GlobalStatsModal.tsx
@@ -69,8 +69,10 @@ export default function GlobalStatsModal({ open, onOpenChange, period, mediaType
           const dateObj = new Date();
           if (period === 'yesterday') dateObj.setDate(dateObj.getDate() - 1);
           const dateStr = dateObj.toISOString().slice(0, 10);
+          // Obtengo la zona horaria del usuario
+          const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
           const res = await fetch(
-            `${BASE_URL}/api/media/stats/hourly-visits?date=${dateStr}&media_type=${mediaType}`,
+            `${BASE_URL}/api/media/stats/hourly-visits?date=${dateStr}&media_type=${mediaType}&timezone=${encodeURIComponent(tz)}`,
             { headers }
           );
           const json = await res.json();


### PR DESCRIPTION
…ísticas globales. Se actualiza la URL de la API para incluir el parámetro de zona horaria, mejorando la precisión de las estadísticas mostradas según la ubicación del usuario.